### PR TITLE
Corrected type file location

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "description": "React.js wrapper for ApexCharts",
   "main": "dist/react-apexcharts.min.js",
-  "types": "dist/react-apexcharts.d.ts",
+  "types": "types/react-apexcharts.d.ts",
   "scripts": {
     "build": "concurrently \"rollup -c rollup.config.js\" \"gulp\"",
     "test": "jest"


### PR DESCRIPTION
I think when I made the previous pull request I accidentally refactored something and made the type directory in the wrong place. I believe the `package.json` should point to `types/react-apexcharts.d.ts` and not `dist` since the gulp is not configured to pipe it there during the build process. I'm not actually familiar with gulp and know if this is a thing that can be done, but I don't think it is necessary since this change allows for the types to be properly detected.