### PR TITLE
Add "rangeBar" to type for ReactApexChart type

### DIFF
--- a/types/react-apexcharts.d.ts
+++ b/types/react-apexcharts.d.ts
@@ -5,7 +5,7 @@
  */
 declare module "react-apexcharts" {
     interface Props {
-        type?: "line" | "area" | "bar" | "histogram" | "pie" | "donut" |
+        type?: "line" | "area" | "bar" | "histogram" | "pie" | "donut" | "rangeBar" |
             "radialBar" | "scatter" | "bubble" | "heatmap" | "candlestick" | "radar",
         series?: Array<any>,
         width?: string | number,


### PR DESCRIPTION
Per this example https://apexcharts.com/react-chart-demos/bar-charts/timeline-chart/# rangeBar is a valid value for a ReactApexChart type.