### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ this.setState({
 | **height** | Number/String | Possible values for width can be `100%` or `300px` or 300 |
 | **options** | Object | The configuration object, see options on [API (Reference)](https://apexcharts.com/docs/options/chart/type/) |
 
-## How to call methods of ApexCharts programatically?
+## How to call methods of ApexCharts programmatically?
 Sometimes, you may want to call other methods of the core ApexCharts library, and you can do so on `ApexCharts` global variable directly
 
 Example


### PR DESCRIPTION
Fixes typo in README:

```
./README.md:105: programatically ==> programmatically
```