### PR TITLE
Add "import React from 'react'; to the types - Fix TS2686 and avoid using tsc --skipLibCheck

### DIFF
--- a/types/react-apexcharts.d.ts
+++ b/types/react-apexcharts.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="react"/>
-import { ApexOptions } from 'apexcharts'
+import { ApexOptions } from 'apexcharts';
+import React from 'react';
 /**
  * Basic type definitions from https://apexcharts.com/docs/react-charts/#props
  */


### PR DESCRIPTION
This PR aims to fix an error when trying to run `tsc`

```
> tsc && vite build

node_modules/react-apexcharts/types/react-apexcharts.d.ts:30:47 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

```

without the react import, the only way to make it compile is `tsc --skipLibCheck`