### PR TITLE
fix type definition import issue

### DIFF
--- a/types/react-apexcharts.d.ts
+++ b/types/react-apexcharts.d.ts
@@ -28,5 +28,10 @@ declare module "react-apexcharts" {
     options?: ApexOptions,
     [key: string]: any,
   }
-  export default class ReactApexChart extends React.Component<Props> {}    
+  export default class ReactApexChart extends React.Component<Props> {
+    render(): React.DetailedReactHTMLElement<{
+      children?: React.ReactNode;
+      ref: React.RefObject<any> | ((el: any) => any) | undefined;
+    }, any>
+  }
 }


### PR DESCRIPTION
Added the `render()` function definition to the `d.ts` file.
This suppresses error
```
Type '{}' is not assignable to type 'ReactNode'.
```
when using legacy version of react and the new version of `CRA`.

### reproduction steps
1. initialize the latest version of `CRA` with the flags `--template typescript`
2. change `react`, `react-dom` and `@types/react` to `^17.0.0` in `package.json`
3. install necessary dependencies (including `apexcharts` and `react-apexcharts`)
4. add `import Chart from "react-apexcharts"` at the top of `App.tsx`
5. remove `App.test.tsx` in case it's causing issues.
6. run `npm start`