### PR TITLE
Fix: react-apexcharts.d.ts typings 

### DIFF
--- a/dist/react-apexcharts.d.ts
+++ b/dist/react-apexcharts.d.ts
@@ -25,7 +25,7 @@ declare module "react-apexcharts" {
     series?: ApexOptions['series'],
     width?: string | number,
     height?: string | number,
-    options?: ApexOptions,
+    options?: ApexOptions | any,
     [key: string]: any,
   }
   export default class ReactApexChart extends React.Component<Props> {}    

--- a/types/react-apexcharts.d.ts
+++ b/types/react-apexcharts.d.ts
@@ -25,7 +25,7 @@ declare module "react-apexcharts" {
     series?: ApexOptions['series'],
     width?: string | number,
     height?: string | number,
-    options?: ApexOptions,
+    options?: ApexOptions | any,
     [key: string]: any,
   }
   export default class ReactApexChart extends React.Component<Props> {


### PR DESCRIPTION


###  How to reproduce
Use  [NEXTJS typescript](https://nextjs.org/docs/basic-features/typescript) then use the apexcharts component and provide a **options** property.  
` <ReactApexChart
        options={optionssalesoverview}
        series={seriessalesoverview}
        type="bar"
        height="295px"
      />`
### The Error displayed 

> Type '{ plotOptions: { bar: { horizontal: boolean; columnWidth: string; endingShape: string; borderRadius: number; }; }; colors: string[]; fill: { type: string; opacity: number; }; dataLabels: { enabled: boolean; }; ... 4 more ...; tooltip: { ...; }; }' is not assignable to type 'ApexOptions'.

### The Fix

### Types

- Changed `   options?: ApexOptions` **to** `   options?: ApexOptions | any`
- Thats it, this fixed my error :)


### Note 
try to use dynamic imports if possible as i have observed this module acts better with dynamic imports ( Only for [NEXTJS ](https://nextjs.org/))
