### PR TITLE
Allow updating options at the same time as series

### DIFF
--- a/src/react-apexcharts.jsx
+++ b/src/react-apexcharts.jsx
@@ -63,17 +63,11 @@ export default function Charts({
     const prevOptions = chart.current.options;
     const prevSeries = chart.current.series;
 
-    if (
-      !deepEqual(prevOptions, options) ||
-      !deepEqual(prevSeries, series) ||
-      height !== chart.current.height ||
-      width !== chart.current.width
-    ) {
-      if (deepEqual(prevSeries, series)) {
-        chart.current.updateOptions(getConfig());
-      } else {
-        chart.current.updateSeries(series);
-      }
+    if (height !== chart.current.height || width !== chart.current.width || !deepEqual(prevOptions, options)) {
+      chart.current.updateOptions(getConfig());
+    }
+    if (!deepEqual(prevSeries, series)) {
+      chart.current.updateSeries(series);
     }
   }, [options, series, height, width]);
 


### PR DESCRIPTION
Hey,
I downloaded your library earlier today and immediately ran into an issue.
I have a checkbox for the user that lets them choose between 2 type of graphs. This modifies both the option (chart.type) and the series, because it has to be computed differently.

With the latest version of react-apexcharts (1.4.4), this doesn't work: the series get updated but not the options.
I tested this change locally and it fixes my issue. It basically just updates whatever needs updating.

Tell me if this is alright! I'd be glad to make any change necessary.